### PR TITLE
Multiple code improvements - squid:S00116, squid:S1213, squid:S1319, squid:S134, squid:S1192, squid:S1301, squid:S1488

### DIFF
--- a/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/helpers/Helpers.java
+++ b/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/helpers/Helpers.java
@@ -13,6 +13,8 @@ import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
 
 public class Helpers {
+    public static final String UNDEFINED = "undefined";
+
     private Handlebars handlebar;
 
     public Helpers(Handlebars handlebar) {
@@ -28,9 +30,7 @@ public class Helpers {
                 int seconds = totalSecs % 60;
                 int miliSec = (int) arg0.doubleValue() % 1000;
 
-                String timeString =
-                    String.format("%02d h : %02d m : %02d s : %02d ms", hours, minutes, seconds, miliSec);
-                return timeString;
+                return String.format("%02d h : %02d m : %02d s : %02d ms", hours, minutes, seconds, miliSec);
             }
         });
 
@@ -45,7 +45,7 @@ public class Helpers {
                     case XMLReporterConfig.TEST_FAILED:
                         return "danger";
                 }
-                return "undefined";
+                return UNDEFINED;
             }
         });
 
@@ -86,20 +86,19 @@ public class Helpers {
                     case "failed":
                         return "This step has failed";
                 }
-                return "undefined";
+                return UNDEFINED;
             }
         });
 
         handlebar.registerHelper("is-collapsed", new Helper<String>() {
             @Override
             public CharSequence apply(String arg0, Options arg1) throws IOException {
-                switch (arg0.toLowerCase()) {
-                    case "passed":
-                        return "collapse";
-                    case "failed":
-                        return "collapse in";
+                if ("passed".equalsIgnoreCase(arg0)) {
+                    return "collapse";
+                } else if("failed".equalsIgnoreCase(arg0)) {
+                    return "collapse in";
                 }
-                return "undefined";
+                return UNDEFINED;
             }
         });
 

--- a/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/xml/models/ExceptionModel.java
+++ b/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/xml/models/ExceptionModel.java
@@ -12,15 +12,15 @@ public class ExceptionModel {
     @XmlAttribute(name = "class")
     private String clazz;
 
-    public String getClazz() {
-        return clazz;
-    }
-
     @XmlElement(name = "message")
     public MessageModel message;
 
     @XmlElement(name = "full-stacktrace")
     public FullStacktraceModel fullStacktrace;
+
+    public String getClazz() {
+        return clazz;
+    }
 
     public MessageModel getMessage() {
         return message;

--- a/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/xml/models/SuiteModel.java
+++ b/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/xml/models/SuiteModel.java
@@ -3,6 +3,7 @@ package com.github.bogdanlivadariu.reporting.testng.xml.models;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -117,7 +118,7 @@ public class SuiteModel {
         return uniqueID;
     }
 
-    public LinkedHashMap<GroupModel, ArrayList<ClassModel>> getGroupedTestMethods() {
+    public Map<GroupModel, ArrayList<ClassModel>> getGroupedTestMethods() {
         return groupedTestMethods;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00116 - Field names should comply with a naming convention.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
squid:S1192 - String literals should not be duplicated.
squid:S1301 - "switch" statements should have at least 3 "case" clauses.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1301
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava