### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:ModifiersOrderCheck, squid:HiddenFieldCheck

### DIFF
--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/cucumber/CucumberTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/cucumber/CucumberTestReportPublisher.java
@@ -33,7 +33,7 @@ import com.github.bogdanlivadariu.reporting.cucumber.builder.CucumberReportBuild
 @SuppressWarnings("unchecked")
 public class CucumberTestReportPublisher extends Recorder {
 
-    private final static String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.json";
+    private static final String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.json";
 
     private final String jsonReportDirectory;
 

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/junit/JUnitTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/junit/JUnitTestReportPublisher.java
@@ -33,7 +33,7 @@ import com.github.bogdanlivadariu.reporting.junit.builder.JUnitReportBuilder;
 @SuppressWarnings("unchecked")
 public class JUnitTestReportPublisher extends Recorder {
 
-    private final static String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.xml";
+    private static final String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.xml";
 
     private final String jsonReportDirectory;
 

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/rspec/RSpecTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/rspec/RSpecTestReportPublisher.java
@@ -33,7 +33,7 @@ import com.github.bogdanlivadariu.reporting.rspec.builder.RSpecReportBuilder;
 @SuppressWarnings("unchecked")
 public class RSpecTestReportPublisher extends Recorder {
 
-    private final static String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.xml";
+    private static final String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.xml";
 
     private final String jsonReportDirectory;
 

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/testng/TestNGTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/testng/TestNGTestReportPublisher.java
@@ -33,7 +33,7 @@ import com.github.bogdanlivadariu.reporting.testng.builder.TestNgReportBuilder;
 @SuppressWarnings("unchecked")
 public class TestNGTestReportPublisher extends Recorder {
 
-    private final static String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.xml";
+    private static final String DEFAULT_FILE_INCLUDE_PATTERN = "**/*.xml";
 
     private final String jsonReportDirectory;
 

--- a/cucumber-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/cucumber/builder/CucumberReportBuilder.java
+++ b/cucumber-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/cucumber/builder/CucumberReportBuilder.java
@@ -142,7 +142,7 @@ public class CucumberReportBuilder {
     }
 
     private List<Feature> prepareData(List<String> jsonReports) throws IOException {
-        List<Feature> processedFeatures = new ArrayList<>();
+        List<Feature> processedFeaturesLocal = new ArrayList<>();
         for (String jsonReport : jsonReports) {
             File jsonFileReport = new File(jsonReport);
             FileInputStream fis = new FileInputStream(jsonFileReport);
@@ -155,11 +155,11 @@ public class CucumberReportBuilder {
             Feature[] features = gs.fromJson(gson, Feature[].class);
 
             for (Feature feature : features) {
-                processedFeatures.add(feature.postProcess());
+                processedFeaturesLocal.add(feature.postProcess());
             }
 
         }
-        return processedFeatures;
+        return processedFeaturesLocal;
     }
 
     /**

--- a/cucumber-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/cucumber/helpers/Helpers.java
+++ b/cucumber-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/cucumber/helpers/Helpers.java
@@ -178,6 +178,8 @@ public class Helpers {
                 return retValue2;
             case Constants.FAILED:
                 return retValue3;
+            default:
+                break;
         }
         return Constants.UNDEFINED;
     }

--- a/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/helpers/Helpers.java
+++ b/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/helpers/Helpers.java
@@ -82,6 +82,8 @@ public class Helpers {
                 return retValue3;
             case Constants.FAILED:
                 return retValue4;
+            default:
+                break;
         }
         return Constants.UNDEFINED;
     }

--- a/rspec-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/rspec/helpers/Helpers.java
+++ b/rspec-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/rspec/helpers/Helpers.java
@@ -82,6 +82,8 @@ public class Helpers {
                 return retVaule3;
             case Constants.FAILED:
                 return retVaule4;
+            default:
+                break;
         }
         return Constants.UNDEFINED;
     }

--- a/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/helpers/Helpers.java
+++ b/testng-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/testng/helpers/Helpers.java
@@ -101,6 +101,8 @@ public class Helpers {
                 return retValue2;
             case FAILED:
                 return retValue3;
+            default:
+                break;
         }
         return retValue4 == null ? UNDEFINED : retValue4;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
squid:HiddenFieldCheck - Local variables should not shadow class fields.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
Please let me know if you have any questions.
George Kankava