### PR TITLE
Avoid Null pointer exception if time is not set

### DIFF
--- a/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuiteModel.java
+++ b/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuiteModel.java
@@ -62,7 +62,7 @@ public class TestSuiteModel {
     }
 
     public String getTime() {
-        return time.replace(",", "");
+        return time == null ? "0" : time.replace(",", "");
     }
 
     public String getErrors() {


### PR DESCRIPTION
For instance if junit report contains: `<testsuite errors="0" failures="0" tests="19" name="SIP URI">`, we should ignore time and set it to 0 instead of null pointer exception.