### PR TITLE
junit: handle <testsuites> root element (#35)

### DIFF
--- a/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuitesModel.java
+++ b/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuitesModel.java
@@ -1,0 +1,85 @@
+package com.github.bogdanlivadariu.reporting.junit.xml.models;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.github.bogdanlivadariu.reporting.junit.helpers.Constants;
+
+@XmlRootElement(name = "testsuites")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TestSuitesModel {
+    @XmlAttribute
+    private String failures;
+
+    @XmlAttribute
+    private String time;
+
+    @XmlAttribute
+    private String errors;
+
+    @XmlAttribute
+    private String tests;
+
+    @XmlAttribute
+    private String name;
+
+    private String uniqueID;
+
+    private String overallStatus;
+
+    @XmlElement(name = "testsuite")
+    private List<TestSuiteModel> testsuite;
+
+    public void postProcess() {
+        uniqueID = UUID.randomUUID().toString();
+
+        if ((failures != null && Integer.parseInt(failures) > 0) || (errors != null && Integer.parseInt(errors) > 0)) {
+            overallStatus = Constants.FAILED;
+        } else {
+            overallStatus = Constants.PASSED;
+        }
+    }
+
+    public String getUniqueID() {
+        return uniqueID;
+    }
+
+    public String getFailures() {
+        return failures == null ? "0" : failures;
+    }
+
+    public String getTime() {
+        return time == null ? "0" : time.replace(",", "");
+    }
+
+    public String getErrors() {
+        return errors == null ? "0" : errors;
+    }
+
+    public String getTests() {
+        return tests == null ? "0" : tests;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<TestSuiteModel> getTestsuite() {
+        return testsuite;
+    }
+
+    public String getOverallStatus() {
+        return overallStatus;
+    }
+
+    public void setTestsuite(List<TestSuiteModel> testsuite) {
+        this.testsuite = testsuite;
+    }
+
+}

--- a/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/AllJunitReportsTest.java
+++ b/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/AllJunitReportsTest.java
@@ -31,7 +31,7 @@ public class AllJunitReportsTest {
     @Test
     public void restSuitesSizeTest() throws FileNotFoundException, JAXBException {
 
-        assertEquals("reports cound is not right", reports.getAllTestSuites().size(), 1);
+        assertEquals("reports count is not right", reports.getAllTestSuites().size(), 1);
 
         assertEquals(reports.getSuitesCount(), 1);
         assertEquals(reports.getTotalErrors(), 0);

--- a/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/JUnitReportBuilderTest.java
+++ b/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/JUnitReportBuilderTest.java
@@ -33,4 +33,17 @@ public class JUnitReportBuilderTest {
         builder = new JUnitReportBuilder(xmlReports, "out");
         assertEquals("reports count is not right", 0, builder.getProcessedTestSuites().size());
     }
+
+    @Test
+    public void processedReportsSuitesTest() throws FileNotFoundException, JAXBException {
+        List<String> xmlReports = new ArrayList<>();
+        String report = this.getClass().getClassLoader().getResource("valid-report-2.xml").getPath();
+        xmlReports.add(report);
+        JUnitReportBuilder builder = new JUnitReportBuilder(xmlReports, "out");
+        assertEquals("reports count is not right", 1, builder.getProcessedTestSuites().size());
+        xmlReports.clear();
+        builder = new JUnitReportBuilder(xmlReports, "out");
+        assertEquals("reports count is not right", 0, builder.getProcessedTestSuites().size());
+    }
 }
+

--- a/junit-reporting-handlebars/src/test/resources/valid-report-2.xml
+++ b/junit-reporting-handlebars/src/test/resources/valid-report-2.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="Cloning Excel file and verifying" tests="13" failures="7" errors="0" skipped="0" time="0.813">
-  <properties />
-  <testcase name="verifyingTheClonedFile" time="0.048" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+<testsuites name="Excel">
+  <testsuite name="Cloning Excel file and verifying" tests="13" failures="7" errors="0" skipped="0" time="0.813">
+    <properties />
+    <testcase name="verifyingTheClonedFile" time="0.048" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -35,9 +36,9 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.113" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.113" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -70,9 +71,9 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.068" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.068" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -105,9 +106,9 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.040" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.040" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -140,9 +141,9 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.046" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.046" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -175,9 +176,9 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.050" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.050" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -210,9 +211,9 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.052" classname="test.java.PlayingWithExcelFiles">
-    <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.052" classname="test.java.PlayingWithExcelFiles">
+      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
   org.testng.Assert.fail(Assert.java:94)
   org.testng.Assert.failNotEquals(Assert.java:496)
   org.testng.Assert.assertTrue(Assert.java:42)
@@ -245,12 +246,13 @@
   org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
   org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
   org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-  </testcase>
-  <testcase name="verifyingTheClonedFile" time="0.068" classname="test.java.PlayingWithExcelFiles" />
-  <testcase name="verifyingTheClonedFile" time="0.065" classname="test.java.PlayingWithExcelFiles" />
-  <testcase name="verifyingTheClonedFile" time="0.044" classname="test.java.PlayingWithExcelFiles" />
-  <testcase name="verifyingTheClonedFile" time="0.120" classname="test.java.PlayingWithExcelFiles" />
-  <testcase name="verifyingTheClonedFile" time="0.051" classname="test.java.PlayingWithExcelFiles" />
-  <testcase name="verifyingTheClonedFile" time="0.048" classname="test.java.PlayingWithExcelFiles" />
-</testsuite>
+    </testcase>
+    <testcase name="verifyingTheClonedFile" time="0.068" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="verifyingTheClonedFile" time="0.065" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="verifyingTheClonedFile" time="0.044" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="verifyingTheClonedFile" time="0.120" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="verifyingTheClonedFile" time="0.051" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="verifyingTheClonedFile" time="0.048" classname="test.java.PlayingWithExcelFiles" />
+  </testsuite>
+</testsuites>
 


### PR DESCRIPTION
I added the TestSuitesModel class even if currently no fields are used in test reports generated.