### PR TITLE
junit: compute missing attributes when missing

### DIFF
--- a/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/helpers/Constants.java
+++ b/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/helpers/Constants.java
@@ -7,7 +7,7 @@ public class Constants {
 
     public static final String ERRORED = "errored";
 
-    protected static final String SKIPPED = "skipped";
+    public static final String SKIPPED = "skipped";
 
     public static final String UNDEFINED = "undefined";
 

--- a/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuiteModel.java
+++ b/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuiteModel.java
@@ -44,8 +44,48 @@ public class TestSuiteModel {
     @XmlElement(name = "testcase")
     private List<TestCaseModel> testcase;
 
+    private Boolean hasMissingAttributes() {
+        return failures == null || time == null || errors == null || tests == null || skipped == null;
+    }
+
     public void postProcess() {
         uniqueID = UUID.randomUUID().toString();
+
+        if (hasMissingAttributes()) {
+            int failuresCount = 0;
+            int skippedCount = 0;
+            int errorsCount = 0;
+            Double totalTime = 0.0;
+
+            for (TestCaseModel test : testcase) {
+                if (test.getOverallStatus().equals(Constants.FAILED)) {
+                    failuresCount++;
+                } else if (test.getOverallStatus().equals(Constants.ERRORED)) {
+                    errorsCount++;
+                } else if (test.getOverallStatus().equals(Constants.SKIPPED)) {
+                    skippedCount++;
+                }
+                totalTime += Double.parseDouble(test.getTime());
+            }
+
+            // update fields if necessary
+            if (failures == null) {
+                failures = Integer.toString(failuresCount);
+            }
+            if (skipped == null) {
+                skipped = Integer.toString(skippedCount);
+            }
+            if (tests == null) {
+                tests = Integer.toString(testcase.size());
+            }
+            if (time == null) {
+                time = Double.toString(totalTime);
+            }
+            if (errors == null) {
+                errors = Integer.toString(errorsCount);
+            }
+        }
+
         if (Integer.parseInt(failures) > 0 || Integer.parseInt(errors) > 0) {
             overallStatus = Constants.FAILED;
         } else {
@@ -58,23 +98,23 @@ public class TestSuiteModel {
     }
 
     public String getFailures() {
-        return failures == null ? "0" : failures;
+        return failures;
     }
 
     public String getTime() {
-        return time == null ? "0" : time.replace(",", "");
+        return time.replace(",", "");
     }
 
     public String getErrors() {
-        return errors == null ? "0" : errors;
+        return errors;
     }
 
     public String getTests() {
-        return tests == null ? "0" : tests;
+        return tests;
     }
 
     public String getSkipped() {
-        return skipped == null ? "0" : skipped;
+        return skipped;
     }
 
     public String getName() {

--- a/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuitesModel.java
+++ b/junit-reporting-handlebars/src/main/java/com/github/bogdanlivadariu/reporting/junit/xml/models/TestSuitesModel.java
@@ -36,10 +36,43 @@ public class TestSuitesModel {
     @XmlElement(name = "testsuite")
     private List<TestSuiteModel> testsuite;
 
+    private Boolean hasMissingAttributes() {
+        return failures == null || time == null || errors == null || tests == null;
+    }
+
     public void postProcess() {
         uniqueID = UUID.randomUUID().toString();
 
-        if ((failures != null && Integer.parseInt(failures) > 0) || (errors != null && Integer.parseInt(errors) > 0)) {
+        if (hasMissingAttributes()) {
+            int failuresCount = 0;
+            int errorsCount = 0;
+            Double totalTime = 0.0;
+
+            for (TestSuiteModel suite : testsuite) {
+                if (suite.getOverallStatus().equals(Constants.FAILED)) {
+                    failuresCount++;
+                } else if (suite.getOverallStatus().equals(Constants.ERRORED)) {
+                    errorsCount++;
+                }
+                totalTime += Double.parseDouble(suite.getTime());
+            }
+
+            // update fields if necessary
+            if (failures == null) {
+                failures = Integer.toString(failuresCount);
+            }
+            if (tests == null) {
+                tests = Integer.toString(testsuite.size());
+            }
+            if (time == null) {
+                time = Double.toString(totalTime);
+            }
+            if (errors == null) {
+                errors = Integer.toString(errorsCount);
+            }
+        }
+
+        if (Integer.parseInt(failures) > 0 || Integer.parseInt(errors) > 0) {
             overallStatus = Constants.FAILED;
         } else {
             overallStatus = Constants.PASSED;
@@ -51,19 +84,19 @@ public class TestSuitesModel {
     }
 
     public String getFailures() {
-        return failures == null ? "0" : failures;
+        return failures;
     }
 
     public String getTime() {
-        return time == null ? "0" : time.replace(",", "");
+        return time.replace(",", "");
     }
 
     public String getErrors() {
-        return errors == null ? "0" : errors;
+        return errors;
     }
 
     public String getTests() {
-        return tests == null ? "0" : tests;
+        return tests;
     }
 
     public String getName() {

--- a/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/AllJunitReportsTestWithSuites.java
+++ b/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/AllJunitReportsTestWithSuites.java
@@ -1,0 +1,71 @@
+package com.github.bogdanlivadariu.reporting.junit.builder;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AllJunitReportsTestWithSuites {
+    List<String> xmlReports;
+
+    String reportPath = this.getClass().getClassLoader().getResource("valid-report-2.xml").getPath();
+
+    JUnitReportBuilder builder;
+
+    AllJUnitReports reports;
+
+    @Before
+    public void setup() throws FileNotFoundException, JAXBException {
+        xmlReports = new ArrayList<>();
+        xmlReports.add(reportPath);
+        builder = new JUnitReportBuilder(xmlReports, "out");
+        reports = new AllJUnitReports("title", builder.getProcessedTestSuites());
+    }
+
+    @Test
+    public void restSuitesSizeTest() throws FileNotFoundException, JAXBException {
+
+        assertEquals("reports count is not right", reports.getAllTestSuites().size(), 2);
+
+        assertEquals(reports.getSuitesCount(), 2);
+        assertEquals(reports.getTotalErrors(), 0);
+
+    }
+
+    @Test
+    public void pageTitleTest() {
+        assertEquals(reports.getPageTitle(), "title");
+    }
+
+    @Test
+    public void totalErrorsTest() {
+        assertEquals(reports.getSuitesCount(), 2);
+    }
+
+    @Test
+    public void totalFailuresTest() {
+        assertEquals(reports.getTotalFailures(), 2);
+    }
+
+    @Test
+    public void totalSkippedTest() {
+        assertEquals(reports.getTotalSkipped(), 0);
+    }
+
+    @Test
+    public void totalTestsTest() {
+        assertEquals(reports.getTotalTests(), 8);
+    }
+
+    @Test
+    public void totalTimeTest() {
+        assertEquals(reports.getTotalTime(), "8.1");
+    }
+
+}

--- a/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/JUnitReportBuilderTest.java
+++ b/junit-reporting-handlebars/src/test/java/com/github/bogdanlivadariu/reporting/junit/builder/JUnitReportBuilderTest.java
@@ -40,7 +40,7 @@ public class JUnitReportBuilderTest {
         String report = this.getClass().getClassLoader().getResource("valid-report-2.xml").getPath();
         xmlReports.add(report);
         JUnitReportBuilder builder = new JUnitReportBuilder(xmlReports, "out");
-        assertEquals("reports count is not right", 1, builder.getProcessedTestSuites().size());
+        assertEquals("reports count is not right", 2, builder.getProcessedTestSuites().size());
         xmlReports.clear();
         builder = new JUnitReportBuilder(xmlReports, "out");
         assertEquals("reports count is not right", 0, builder.getProcessedTestSuites().size());

--- a/junit-reporting-handlebars/src/test/resources/valid-report-2.xml
+++ b/junit-reporting-handlebars/src/test/resources/valid-report-2.xml
@@ -1,258 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Excel">
-  <testsuite name="Cloning Excel file and verifying" tests="13" failures="7" errors="0" skipped="0" time="0.813">
-    <properties />
-    <testcase name="verifyingTheClonedFile" time="0.048" classname="test.java.PlayingWithExcelFiles">
+<testsuites name="TXT">
+  <testsuite name="Cloning TXT file and verifying" tests="6" failures="1" errors="0" skipped="0" time="6.1">
+    <testcase name="test 1" time="0.1" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="test 2" time="0.7" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="test 3" time="0.9" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="test 4" time="1" classname="test.java.PlayingWithExcelFiles" />
+    <testcase name="test 5" time="3" classname="test.java.PlayingWithExcelFiles" >
       <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-    </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.113" classname="test.java.PlayingWithExcelFiles">
+    org.testng.Assert.fail(Assert.java:94)
+    org.testng.Assert.failNotEquals(Assert.java:496)
+    org.testng.Assert.assertTrue(Assert.java:42)
+    test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
+    sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+    sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+    sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+    org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
+    org.testng.TestNG.run(TestNG.java:1032)
+    org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
+    org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
+    org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
+    org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
+    org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
+    org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
+  </testcase>
+    <testcase name="test 6" time="0.4" classname="test.java.PlayingWithExcelFiles" />
+  </testsuite>
+  <testsuite name="Alternate test suite">
+    <testcase name="alternate test 1" time="0.1" classname="test.java.AlternateTestSuite" />
+    <testcase name="alternate test 2" time="1.900" classname="test.java.AlternateTestSuite" >
       <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
+    org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
     </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.068" classname="test.java.PlayingWithExcelFiles">
-      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-    </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.040" classname="test.java.PlayingWithExcelFiles">
-      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-    </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.046" classname="test.java.PlayingWithExcelFiles">
-      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-    </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.050" classname="test.java.PlayingWithExcelFiles">
-      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-    </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.052" classname="test.java.PlayingWithExcelFiles">
-      <failure type="java.lang.AssertionError" message="Test failed as 'pass' was not found expected [true] but found [false]"><![CDATA[java.lang.AssertionError: Test failed as 'pass' was not found expected [true] but found [false]
-  org.testng.Assert.fail(Assert.java:94)
-  org.testng.Assert.failNotEquals(Assert.java:496)
-  org.testng.Assert.assertTrue(Assert.java:42)
-  test.java.PlayingWithExcelFiles.verifyingTheClonedFile(PlayingWithExcelFiles.java:35)
-  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-  java.lang.reflect.Method.invoke(Method.java:483)
-  org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
-  org.testng.internal.Invoker.invokeMethod(Invoker.java:659)
-  org.testng.internal.Invoker.invokeTestMethod(Invoker.java:845)
-  org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1153)
-  org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
-  org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:108)
-  org.testng.TestRunner.privateRun(TestRunner.java:771)
-  org.testng.TestRunner.run(TestRunner.java:621)
-  org.testng.SuiteRunner.runTest(SuiteRunner.java:357)
-  org.testng.SuiteRunner.runSequentially(SuiteRunner.java:352)
-  org.testng.SuiteRunner.privateRun(SuiteRunner.java:310)
-  org.testng.SuiteRunner.run(SuiteRunner.java:259)
-  org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
-  org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1199)
-  org.testng.TestNG.runSuitesSequentially(TestNG.java:1195)
-  org.testng.TestNG.runSuitesLocally(TestNG.java:1124)
-  org.testng.TestNG.run(TestNG.java:1032)
-  org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:295)
-  org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
-  org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:90)
-  org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
-  org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
-  org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)]]></failure>
-    </testcase>
-    <testcase name="verifyingTheClonedFile" time="0.068" classname="test.java.PlayingWithExcelFiles" />
-    <testcase name="verifyingTheClonedFile" time="0.065" classname="test.java.PlayingWithExcelFiles" />
-    <testcase name="verifyingTheClonedFile" time="0.044" classname="test.java.PlayingWithExcelFiles" />
-    <testcase name="verifyingTheClonedFile" time="0.120" classname="test.java.PlayingWithExcelFiles" />
-    <testcase name="verifyingTheClonedFile" time="0.051" classname="test.java.PlayingWithExcelFiles" />
-    <testcase name="verifyingTheClonedFile" time="0.048" classname="test.java.PlayingWithExcelFiles" />
   </testsuite>
 </testsuites>
 


### PR DESCRIPTION
`total time, failures & errors count`, etc. are postProcessed if not set in XML.
Instead of returning `0` default value, we may compute them directly from the list of test cases.

In my case, I am using an old&dead C unit-test framework that write the junit XML report sequentially while executing tests, so it does not know how much failures will there be in advance; it's a pain to write file in C, so we do not modify it afterward. 
However, the framework fills `testcase` properties properly (including duration, failures, etc.), so these informations can be rised up to the `testsuite` afterward (which is the aim of this PR). 