### PR TITLE
Use HTTPS for resolution

### DIFF
--- a/bootstraped-multi-test-results-report/pom.xml
+++ b/bootstraped-multi-test-results-report/pom.xml
@@ -47,13 +47,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
HTTP has been deprecated for a while now.
This prevents local builds of the plugin.