### PR TITLE
Do not sign artifacts until publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>


### PR DESCRIPTION
Local development requires `mvn verify` to run checks.
Not all developers or CI systems are likely to have the right gpg configured to sign.
Signing is only required for publishing artifacts.