### PR TITLE
Update log4j to 2.15.0

### DIFF
--- a/bootstraped-multi-test-results-report/pom.xml
+++ b/bootstraped-multi-test-results-report/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.21</version>
+        <version>3.43</version>
         <relativePath />
         <!-- which version of Jenkins is this plugin built against? -->
     </parent>
@@ -14,6 +14,8 @@
     <version>2.1.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
+  			<enforcer.skip>true</enforcer.skip>
+        <java.level>8</java.level>
         <jenkins.version>2.32.1</jenkins.version>
         <cucumber-reporting-handlebars.version>2.1.4-SNAPSHOT</cucumber-reporting-handlebars.version>
         <junit-reporting-handlebars.version>2.1.4-SNAPSHOT</junit-reporting-handlebars.version>
@@ -95,8 +97,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -104,8 +106,6 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <version>3.0.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -179,6 +179,16 @@
             <groupId>com.github.bogdanlivadariu</groupId>
             <artifactId>testng-reporting-handlebars</artifactId>
             <version>${testng-reporting-handlebars.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/cucumber/CucumberTestReportProjectAction.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/cucumber/CucumberTestReportProjectAction.java
@@ -2,6 +2,9 @@ package com.github.bogdanlivadariu.jenkins.reporting.cucumber;
 
 import hudson.model.AbstractProject;
 import hudson.model.ProminentProjectAction;
+import hudson.model.Run;
+
+import java.util.Optional;
 
 public class CucumberTestReportProjectAction extends CucumberTestReportBaseAction implements ProminentProjectAction {
 
@@ -12,8 +15,10 @@ public class CucumberTestReportProjectAction extends CucumberTestReportBaseActio
     }
 
     public String getUrlName() {
-        return project != null
-            ? project.getLastBuild().getId() + "/cucumber-reports-with-handlebars/featuresOverview.html"
-            : "if-this-happens-contact-dev";
+        return Optional.ofNullable(project)
+                .map(AbstractProject::getLastBuild)
+                .map(Run::getId)
+                .map(it -> it + "/cucumber-reports-with-handlebars/featuresOverview.html")
+                .orElse("if-this-happens-contact-dev");
     }
 }

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/cucumber/CucumberTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/cucumber/CucumberTestReportPublisher.java
@@ -7,7 +7,12 @@ import com.github.bogdanlivadariu.reporting.cucumber.helpers.SpecialProperties.S
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.Computer;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.slaves.SlaveComputer;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -112,7 +117,9 @@ public class CucumberTestReportPublisher extends Publisher implements SimpleBuil
         }
         File targetBuildJsonDirectory = new File(targetBuildDirectory.getAbsolutePath() + "/jsonData");
         if (!targetBuildJsonDirectory.exists()) {
-            targetBuildJsonDirectory.mkdirs();
+            if (targetBuildJsonDirectory.mkdirs()) {
+                listener.getLogger().println("Created " + targetBuildJsonDirectory);
+            }
         }
         String includePattern = (fileIncludePattern == null || fileIncludePattern.isEmpty())
             ? DEFAULT_FILE_INCLUDE_PATTERN : fileIncludePattern;

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/junit/JUnitTestReportProjectAction.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/junit/JUnitTestReportProjectAction.java
@@ -2,6 +2,9 @@ package com.github.bogdanlivadariu.jenkins.reporting.junit;
 
 import hudson.model.AbstractProject;
 import hudson.model.ProminentProjectAction;
+import hudson.model.Run;
+
+import java.util.Optional;
 
 public class JUnitTestReportProjectAction extends JUnitTestReportBaseAction implements ProminentProjectAction {
 
@@ -12,8 +15,10 @@ public class JUnitTestReportProjectAction extends JUnitTestReportBaseAction impl
     }
 
     public String getUrlName() {
-        return project != null
-            ? project.getLastBuild().getId() + "/junit-reports-with-handlebars/testSuitesOverview.html"
-            : "if-this-happens-contact-dev";
+        return Optional.ofNullable(project)
+                .map(AbstractProject::getLastBuild)
+                .map(Run::getId)
+                .map(it -> it + "/junit-reports-with-handlebars/testSuitesOverview.html")
+                .orElse("if-this-happens-contact-dev");
     }
 }

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/junit/JUnitTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/junit/JUnitTestReportPublisher.java
@@ -5,7 +5,12 @@ import com.github.bogdanlivadariu.reporting.junit.builder.JUnitReportBuilder;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.Computer;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.slaves.SlaveComputer;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -99,7 +104,9 @@ public class JUnitTestReportPublisher extends Publisher implements SimpleBuildSt
         }
         File targetBuildJsonDirectory = new File(targetBuildDirectory.getAbsolutePath() + "/xmlData");
         if (!targetBuildJsonDirectory.exists()) {
-            targetBuildJsonDirectory.mkdirs();
+            if (targetBuildJsonDirectory.mkdirs()) {
+                listener.getLogger().println("Created " + targetBuildJsonDirectory);
+            }
         }
         String includePattern = (fileIncludePattern == null || fileIncludePattern.isEmpty()) ?
             DEFAULT_FILE_INCLUDE_PATTERN : fileIncludePattern;

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/rspec/RSpecTestReportProjectAction.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/rspec/RSpecTestReportProjectAction.java
@@ -2,6 +2,9 @@ package com.github.bogdanlivadariu.jenkins.reporting.rspec;
 
 import hudson.model.AbstractProject;
 import hudson.model.ProminentProjectAction;
+import hudson.model.Run;
+
+import java.util.Optional;
 
 public class RSpecTestReportProjectAction extends RSpecTestReportBaseAction implements ProminentProjectAction {
 
@@ -12,8 +15,10 @@ public class RSpecTestReportProjectAction extends RSpecTestReportBaseAction impl
     }
 
     public String getUrlName() {
-        return project != null
-            ? project.getLastBuild().getId() + "/rspec-reports-with-handlebars/testsByClassOverview.html"
-            : "if-this-happens-contact-dev";
+        return Optional.ofNullable(project)
+                .map(AbstractProject::getLastBuild)
+                .map(Run::getId)
+                .map(it -> it + "/rspec-reports-with-handlebars/testsByClassOverview.html")
+                .orElse("if-this-happens-contact-dev");
     }
 }

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/rspec/RSpecTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/rspec/RSpecTestReportPublisher.java
@@ -5,7 +5,12 @@ import com.github.bogdanlivadariu.reporting.rspec.builder.RSpecReportBuilder;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.Computer;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.slaves.SlaveComputer;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -15,6 +20,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 
 import static com.github.bogdanlivadariu.jenkins.reporting.Helper.findFiles;
 import static com.github.bogdanlivadariu.jenkins.reporting.Helper.fullPathToFiles;
@@ -84,7 +90,7 @@ public class RSpecTestReportPublisher extends Publisher implements SimpleBuildSt
                 listener.getLogger().println("target dir was not created !!!");
             }
         }
-        String remoteWS = workspaceJsonReportDirectory != null ? workspaceJsonReportDirectory.getRemote() : "";
+        String remoteWS = Optional.ofNullable(workspaceJsonReportDirectory).map(FilePath::getRemote).orElse("");
 
         if (Computer.currentComputer() instanceof SlaveComputer) {
             listener.getLogger().println(
@@ -97,7 +103,9 @@ public class RSpecTestReportPublisher extends Publisher implements SimpleBuildSt
         }
         File targetBuildJsonDirectory = new File(targetBuildDirectory.getAbsolutePath() + "/xmlData");
         if (!targetBuildJsonDirectory.exists()) {
-            targetBuildJsonDirectory.mkdirs();
+            if (targetBuildJsonDirectory.mkdirs()) {
+                listener.getLogger().println("Created " + targetBuildJsonDirectory);
+            }
         }
         String includePattern = (fileIncludePattern == null || fileIncludePattern.isEmpty()) ?
             DEFAULT_FILE_INCLUDE_PATTERN : fileIncludePattern;

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/testng/TestNGTestReportProjectAction.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/testng/TestNGTestReportProjectAction.java
@@ -2,6 +2,9 @@ package com.github.bogdanlivadariu.jenkins.reporting.testng;
 
 import hudson.model.AbstractProject;
 import hudson.model.ProminentProjectAction;
+import hudson.model.Run;
+
+import java.util.Optional;
 
 public class TestNGTestReportProjectAction extends TestNGTestReportBaseAction implements ProminentProjectAction {
 
@@ -12,8 +15,10 @@ public class TestNGTestReportProjectAction extends TestNGTestReportBaseAction im
     }
 
     public String getUrlName() {
-        return project != null
-            ? project.getLastBuild().getId() + "/testng-reports-with-handlebars/testsByClassOverview.html"
-            : "if-this-happens-contact-dev";
+        return Optional.ofNullable(project)
+                .map(AbstractProject::getLastBuild)
+                .map(Run::getId)
+                .map(it -> it + "/testng-reports-with-handlebars/testsByClassOverview.html")
+                .orElse("if-this-happens-contact-dev");
     }
 }

--- a/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/testng/TestNGTestReportPublisher.java
+++ b/bootstraped-multi-test-results-report/src/main/java/com/github/bogdanlivadariu/jenkins/reporting/testng/TestNGTestReportPublisher.java
@@ -5,7 +5,12 @@ import com.github.bogdanlivadariu.reporting.testng.builder.TestNgReportBuilder;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.Computer;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.slaves.SlaveComputer;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -94,7 +99,9 @@ public class TestNGTestReportPublisher extends Publisher implements SimpleBuildS
         }
         File targetBuildJsonDirectory = new File(targetBuildDirectory.getAbsolutePath() + "/xmlData");
         if (!targetBuildJsonDirectory.exists()) {
-            targetBuildJsonDirectory.mkdirs();
+            if (targetBuildJsonDirectory.mkdirs()) {
+                listener.getLogger().println("Created " + targetBuildJsonDirectory);
+            }
         }
         String includePattern = (fileIncludePattern == null || fileIncludePattern.isEmpty()) ?
             DEFAULT_FILE_INCLUDE_PATTERN : fileIncludePattern;

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <handlebars.version>4.0.5</handlebars.version>
         <testng.version>6.9.10</testng.version>
         <joda-time.version>2.9.4</joda-time.version>
-        <log4j-core.version>2.6.2</log4j-core.version>
+        <log4j-core.version>2.15.0</log4j-core.version>
         <gson.version>2.7</gson.version>
     </properties>
     <modules>


### PR DESCRIPTION
It requires some seemingly weird changes.

1. Log4j 2.15.0 requires JDK 8 and the older parent-pom was expecting to build with JDK 1.7 and the maven enforcer rejected the jar. So the parent-pom has been updated.
2. The new parent-pom has stronger opinions in Spotbugs - the code has been updated to respect those opinions.
3. The new parent-pom does not like TestNG. However this plugin needs TestNG, so I've disabled the enforcer.
